### PR TITLE
Fix conflict with other `SaberModelRegistration` providers

### DIFF
--- a/SaberFactory/Installers/PluginGameInstaller.cs
+++ b/SaberFactory/Installers/PluginGameInstaller.cs
@@ -34,7 +34,7 @@ namespace SaberFactory.Installers
 
             //Container.BindInterfacesAndSelfTo<AFHandler>().AsSingle();
             Container.BindInterfacesAndSelfTo<GameSaberSetup>().AsSingle();
-            Container.BindInstance(SaberModelRegistration.Create<SfSaberModelController>(300)).AsSingle();
+            Container.BindInstance(SaberModelRegistration.Create<SfSaberModelController>(300));
 
 #if DEBUG && TEST_TRAIL
             if (Container.TryResolve<LaunchOptions>()?.FPFC ?? false)


### PR DESCRIPTION
When an instance of `SaberModelRegistration` is bound `.AsSingle`, no other instances of it can be bound, causing conflicts in other mods.
See: https://discord.com/channels/441805394323439646/864240224400572467/943442654602092545