### PR TITLE
Moved SetupGlobalShaderVars

### DIFF
--- a/SaberFactory/Editor/Editor.cs
+++ b/SaberFactory/Editor/Editor.cs
@@ -105,7 +105,6 @@ namespace SaberFactory.Editor
 #if PAT
             SetPedestalText(2, "<color=#ffffff80>Patreon ♥</color>");
 #endif
-            SetupGlobalShaderVars();
         }
 
         public async void Open()
@@ -217,13 +216,6 @@ namespace SaberFactory.Editor
             {
                 await AnimationHelper.AsyncAnimation(0.3f, CancellationToken.None, t => { parent.localScale = new Vector3(t, t, t); });
             }
-        }
-
-        private void SetupGlobalShaderVars()
-        {
-            var scheme = _playerDataModel.playerData.colorSchemesSettings.GetSelectedColorScheme();
-            Shader.SetGlobalColor(MaterialProperties.UserColorLeft, scheme.saberAColor);
-            Shader.SetGlobalColor(MaterialProperties.UserColorRight, scheme.saberBColor);
         }
     }
 }

--- a/SaberFactory/Instances/SaberInstance.cs
+++ b/SaberFactory/Instances/SaberInstance.cs
@@ -37,6 +37,7 @@ namespace SaberFactory.Instances
 
         private InstanceTrailData _instanceTrailData;
         private List<CustomSaberTrailHandler> _secondaryTrails;
+        private readonly PlayerDataModel _playerDataModel;
 
         private readonly Dictionary<Type, Component> _saberComponents = new Dictionary<Type, Component>();
 
@@ -45,10 +46,12 @@ namespace SaberFactory.Instances
             BasePieceInstance.Factory pieceFactory,
             SiraLog logger,
             TrailConfig trailConfig,
-            List<ISaberPostProcessor> saberMiddlewares)
+            List<ISaberPostProcessor> saberMiddlewares,
+            PlayerDataModel playerDataModel)
         {
             _logger = logger;
             _trailConfig = trailConfig;
+            _playerDataModel = playerDataModel;
 
             Model = model;
 
@@ -66,6 +69,7 @@ namespace SaberFactory.Instances
 
             saberMiddlewares.Do(x => x.ProcessSaber(this));
 
+            SetupGlobalShaderVars();
             SetupTrailData();
             InitializeEvents();
         }
@@ -222,6 +226,13 @@ namespace SaberFactory.Instances
         {
             Model.SaberLength = length;
             GameObject.transform.localScale = new Vector3(Model.SaberWidth, Model.SaberWidth, length);
+        }
+
+        private void SetupGlobalShaderVars()
+        {
+            var scheme = _playerDataModel.playerData.colorSchemesSettings.GetSelectedColorScheme();
+            Shader.SetGlobalColor(MaterialProperties.UserColorLeft, scheme.saberAColor);
+            Shader.SetGlobalColor(MaterialProperties.UserColorRight, scheme.saberBColor);
         }
 
         internal class Factory : PlaceholderFactory<SaberModel, SaberInstance>


### PR DESCRIPTION
Moved the SetupGlobalShaderVars method to the SaberInstance class so that they get updated every time a saber is created.

this fixes the global vars "_UserColorLeft" and "_UserColorRight" not being updated after initialization.

Fixes #136