### PR TITLE
Hide promotion badges and background introduced in 1.28.0

### DIFF
--- a/SaberFactory/UI/Lib/BSML/CustomListTableData.cs
+++ b/SaberFactory/UI/Lib/BSML/CustomListTableData.cs
@@ -199,6 +199,13 @@ namespace SaberFactory.UI.Lib.BSML
                 tableCell.SetField("_highlightBackgroundColor", new Color(0.360f, 0.647f, 1, 0.7f));
                 tableCell.SetField("_selectedBackgroundColor", new Color(0.360f, 0.647f, 1, 0.9f));
                 tableCell.SetField("_selectedAndHighlightedBackgroundColor", new Color(0.360f, 0.647f, 1, 0.9f));
+                
+                // copied directly from BSML, hide the promotion badges introduced in 1.28.0
+                tableCell.GetField<GameObject, LevelListTableCell>("_promoBackgroundGo").SetActive(false);
+                tableCell.GetField<GameObject, LevelListTableCell>("_promoBadgeGo").SetActive(false);
+                tableCell.GetField<GameObject, LevelListTableCell>("_updatedBadgeGo").SetActive(false);
+                tableCell.GetField<LayoutWidthLimiter, LevelListTableCell>("_layoutWidthLimiter").limitWidth = false;
+                
                 var bg = _backgroundImageAccessor(ref tableCell).Cast<ImageView>();
                 bg.SetSkew(0);
                 bg.color1 = bg.color1.ColorWithAlpha(0.4f);

--- a/SaberFactory/manifest.json
+++ b/SaberFactory/manifest.json
@@ -3,9 +3,9 @@
   "id": "SaberFactory",
   "name": "Saber Factory",
   "author": "Toni Macaroni",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "A highly customizable saber mod",
-  "gameVersion": "1.27.0",
+  "gameVersion": "1.28.0",
   "dependsOn": {
     "BSIPA": "^4.2.2",
     "SiraUtil": "^3.1.2",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31044781/223595742-1ff1bfe1-d558-4222-82e3-793749878dd9.png)
![image](https://user-images.githubusercontent.com/31044781/223595774-c0f85a8a-6285-4dfc-a059-e2decdd1d1e6.png)
